### PR TITLE
Added possibility to use the OpenSilver.dll

### DIFF
--- a/CSHTML5.Tools.AssemblyAnalysisCommon/Analyzer/CoreSupportedMethodsContainer.cs
+++ b/CSHTML5.Tools.AssemblyAnalysisCommon/Analyzer/CoreSupportedMethodsContainer.cs
@@ -18,12 +18,16 @@ namespace DotNetForHtml5.PrivateTools.AssemblyCompatibilityAnalyzer
             _coreAssemblyFolder = coreAssemblyFolder;
             _coreAssembliesPaths = new string[]
             {
+#if CSHTML5
                 Path.Combine(_coreAssemblyFolder, @"SLMigration.CSharpXamlForHtml5.dll"),
                 Path.Combine(_coreAssemblyFolder, @"SLMigration.CSharpXamlForHtml5.System.dll.dll"),
                 Path.Combine(_coreAssemblyFolder, @"SLMigration.CSharpXamlForHtml5.System.Runtime.Serialization.dll.dll"),
                 Path.Combine(_coreAssemblyFolder, @"SLMigration.CSharpXamlForHtml5.System.ServiceModel.dll.dll"),
                 Path.Combine(_coreAssemblyFolder, @"SLMigration.CSharpXamlForHtml5.System.Xaml.dll.dll"),
                 Path.Combine(_coreAssemblyFolder, @"SLMigration.CSharpXamlForHtml5.System.Xml.dll.dll"),
+#else
+                Path.Combine(_coreAssemblyFolder, @"OpenSilver.dll"),
+#endif
             };
             Initialize();
         }

--- a/CSHTML5.Tools.AssemblyAnalysisCommon/CSHTML5.Tools.AssemblyAnalysisCommon.csproj
+++ b/CSHTML5.Tools.AssemblyAnalysisCommon/CSHTML5.Tools.AssemblyAnalysisCommon.csproj
@@ -1,76 +1,25 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{8BD10359-5315-4F6A-B82C-B0B0862ED4A2}</ProjectGuid>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>CSHTML5.Tools.AssemblyAnalysisCommon</RootNamespace>
-    <AssemblyName>CSHTML5.Tools.AssemblyAnalysisCommon</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <Deterministic>true</Deterministic>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <Configurations>CSHTML5;OpenSilver</Configurations>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'CSHTML5|AnyCPU' ">
+	  <DefineConstants>TRACE;DEBUG;CSHTML</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'OpenSilver|AnyCPU' ">
+	  <DefineConstants>TRACE;DEBUG;OPENSILVER</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Build.Framework" />
-    <Reference Include="Mono.Cecil, Version=0.11.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
-      <HintPath>..\packages\Mono.Cecil.0.11.0\lib\net40\Mono.Cecil.dll</HintPath>
-    </Reference>
-    <Reference Include="Mono.Cecil.Mdb, Version=0.11.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
-      <HintPath>..\packages\Mono.Cecil.0.11.0\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
-    </Reference>
-    <Reference Include="Mono.Cecil.Pdb, Version=0.11.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
-      <HintPath>..\packages\Mono.Cecil.0.11.0\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
-    </Reference>
-    <Reference Include="Mono.Cecil.Rocks, Version=0.11.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
-      <HintPath>..\packages\Mono.Cecil.0.11.0\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Analyzer\AnalyzeHelper.cs" />
-    <Compile Include="Analyzer\CompatibilityAnalyzer.cs" />
-    <Compile Include="Analyzer\CoreSupportedMethodsContainer.cs" />
-    <Compile Include="Analyzer\CoreSupportedMethodTypeItem.cs" />
-    <Compile Include="Analyzer\ILogger.cs" />
-    <Compile Include="Analyzer\LoggerThatAggregatesAllErrors.cs" />
-    <Compile Include="Analyzer\MemberReferenceAndCallerInformation.cs" />
-    <Compile Include="Analyzer\MemberReferenceHelper.cs" />
-    <Compile Include="Analyzer\UnsupportedMethodInfo.cs" />
-    <Compile Include="Helpers\AccessModifierEnum.cs" />
-    <Compile Include="Helpers\AnalysisUtils.cs" />
-    <Compile Include="Helpers\MethodType.cs" />
-    <Compile Include="Helpers\TypeEnum.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="16.9.0" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <PackageReference Include="Mono.Cecil" Version="0.11.0" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/CSHTML5.Tools.AssemblyAnalysisCommon/packages.config
+++ b/CSHTML5.Tools.AssemblyAnalysisCommon/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Mono.Cecil" version="0.11.0" targetFramework="net45" />
-</packages>

--- a/CSHTML5.Tools.CompatibilityAnalyzer.App/App.config
+++ b/CSHTML5.Tools.CompatibilityAnalyzer.App/App.config
@@ -1,35 +1,35 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <configSections>
-        <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" >
-            <section name="CSHTML5.Tools.CompatibilityAnalyzer.App.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
+        <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+            <section name="CSHTML5.Tools.CompatibilityAnalyzer.App.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false"/>
         </sectionGroup>
     </configSections>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
     </startup>
     <userSettings>
         <CSHTML5.Tools.CompatibilityAnalyzer.App.Properties.Settings>
             <setting name="OtherFoldersPath" serializeAs="String">
-                <value />
+                <value/>
             </setting>
             <setting name="CoreAssemblyPath" serializeAs="String">
-                <value />
+                <value/>
             </setting>
             <setting name="FeaturesAndEstimationsPath" serializeAs="String">
-                <value />
+                <value/>
             </setting>
             <setting name="MscorlibFolderPath" serializeAs="String">
-                <value />
+                <value/>
             </setting>
             <setting name="SDKFolderPath" serializeAs="String">
-                <value />
+                <value/>
             </setting>
             <setting name="SupportedElementsPath" serializeAs="String">
-                <value />
+                <value/>
             </setting>
             <setting name="XamlFilesToIgnore" serializeAs="String">
-                <value />
+                <value/>
             </setting>
         </CSHTML5.Tools.CompatibilityAnalyzer.App.Properties.Settings>
     </userSettings>

--- a/CSHTML5.Tools.CompatibilityAnalyzer.App/CSHTML5.Tools.CompatibilityAnalyzer.App.csproj
+++ b/CSHTML5.Tools.CompatibilityAnalyzer.App/CSHTML5.Tools.CompatibilityAnalyzer.App.csproj
@@ -1,52 +1,21 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{99771B41-0FCF-46A7-AC96-ED557EC05DD6}</ProjectGuid>
+    <TargetFramework>net472</TargetFramework>
     <OutputType>WinExe</OutputType>
-    <RootNamespace>CSHTML5.Tools.CompatibilityAnalyzer.App</RootNamespace>
-    <AssemblyName>CSHTML5.Tools.CompatibilityAnalyzer.App</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <WarningLevel>4</WarningLevel>
-    <Deterministic>true</Deterministic>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <UseWPF>true</UseWPF>
+    <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
+    <Configurations>CSHTML5;OpenSilver</Configurations>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;ASK_USER_TO_CHOOSE_ASSEMBLIES_TO_ANALYZE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'CSHTML5|AnyCPU' ">
+    <DefineConstants>TRACE;DEBUG;ASK_USER_TO_CHOOSE_ASSEMBLIES_TO_ANALYZE;CSHTML</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'OpenSilver|AnyCPU' ">
+    <DefineConstants>TRACE;DEBUG;ASK_USER_TO_CHOOSE_ASSEMBLIES_TO_ANALYZE;OPENSILVER</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Build.Framework" />
-    <Reference Include="Mono.Cecil, Version=0.11.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
-      <HintPath>..\packages\Mono.Cecil.0.11.0\lib\net40\Mono.Cecil.dll</HintPath>
-    </Reference>
-    <Reference Include="Mono.Cecil.Mdb, Version=0.11.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
-      <HintPath>..\packages\Mono.Cecil.0.11.0\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
-    </Reference>
-    <Reference Include="Mono.Cecil.Pdb, Version=0.11.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
-      <HintPath>..\packages\Mono.Cecil.0.11.0\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
-    </Reference>
-    <Reference Include="Mono.Cecil.Rocks, Version=0.11.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
-      <HintPath>..\packages\Mono.Cecil.0.11.0\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
-    </Reference>
+	  <!--
     <Reference Include="Syncfusion.Compression.Base, Version=16.1450.0.37, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>SyncfusionLibs_NotProvidedBecauseALicenseIsRequired\Syncfusion.Compression.Base.dll</HintPath>
@@ -55,87 +24,23 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>SyncfusionLibs_NotProvidedBecauseALicenseIsRequired\Syncfusion.XlsIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="System.Xml" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xaml">
-      <RequiredTargetFramework>4.0</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="WindowsBase" />
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
+	-->
   </ItemGroup>
   <ItemGroup>
-    <ApplicationDefinition Include="App.xaml">
-      <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
-    </ApplicationDefinition>
-    <Page Include="MainWindow.xaml">
-      <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
-    </Page>
-    <Compile Include="App.xaml.cs">
-      <DependentUpon>App.xaml</DependentUpon>
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Configuration.cs" />
-    <Compile Include="CsvGenerator.cs" />
-    <Compile Include="ExcelGenerator.cs" />
-    <Compile Include="FeaturesAndEstimationsFileProcessor.cs" />
-    <Compile Include="HashSetHelpers.cs" />
-    <Compile Include="MainWindow.xaml.cs">
-      <DependentUpon>MainWindow.xaml</DependentUpon>
-      <SubType>Code</SubType>
-    </Compile>
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="MergingRelatedClasses.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Properties\Resources.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-      <DependentUpon>Resources.resx</DependentUpon>
-    </Compile>
-    <Compile Include="Properties\Settings.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DependentUpon>Settings.settings</DependentUpon>
-      <DesignTimeSharedInput>True</DesignTimeSharedInput>
-    </Compile>
-    <EmbeddedResource Include="Properties\Resources.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
-    </EmbeddedResource>
-    <None Include="packages.config" />
-    <None Include="Properties\Settings.settings">
-      <Generator>SettingsSingleFileGenerator</Generator>
-      <LastGenOutput>Settings.Designer.cs</LastGenOutput>
-    </None>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="App.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\CSHTML5.Tools.AssemblyAnalysisCommon\CSHTML5.Tools.AssemblyAnalysisCommon.csproj">
-      <Project>{8bd10359-5315-4f6a-b82c-b0b0862ed4a2}</Project>
-      <Name>CSHTML5.Tools.AssemblyAnalysisCommon</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\CSHTML5.Tools.AssemblyAnalysisCommon\CSHTML5.Tools.AssemblyAnalysisCommon.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Resources\BridgeSupportedElements.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+	  <!--
     <Content Include="SyncfusionLibs_NotProvidedBecauseALicenseIsRequired\Syncfusion.Compression.Base.dll" />
     <Resource Include="SyncfusionLibs_NotProvidedBecauseALicenseIsRequired\Syncfusion.Compression.Base.xml" />
     <Content Include="SyncfusionLibs_NotProvidedBecauseALicenseIsRequired\Syncfusion.XlsIO.Base.dll" />
     <Resource Include="SyncfusionLibs_NotProvidedBecauseALicenseIsRequired\Syncfusion.XlsIO.Base.xml" />
+	-->
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <ItemGroup>
+    <PackageReference Include="Syncfusion.XlsIO.Wpf" Version="19.1.0.55" />
+  </ItemGroup>
 </Project>

--- a/CSHTML5.Tools.CompatibilityAnalyzer.App/Properties/Resources.Designer.cs
+++ b/CSHTML5.Tools.CompatibilityAnalyzer.App/Properties/Resources.Designer.cs
@@ -8,10 +8,10 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace CSHTML5.Tools.CompatibilityAnalyzer.App.Properties
-{
-
-
+namespace CSHTML5.Tools.CompatibilityAnalyzer.App.Properties {
+    using System;
+    
+    
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -19,51 +19,43 @@ namespace CSHTML5.Tools.CompatibilityAnalyzer.App.Properties
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    internal class Resources
-    {
-
+    internal class Resources {
+        
         private static global::System.Resources.ResourceManager resourceMan;
-
+        
         private static global::System.Globalization.CultureInfo resourceCulture;
-
+        
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
-        internal Resources()
-        {
+        internal Resources() {
         }
-
+        
         /// <summary>
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Resources.ResourceManager ResourceManager
-        {
-            get
-            {
-                if ((resourceMan == null))
-                {
+        internal static global::System.Resources.ResourceManager ResourceManager {
+            get {
+                if (object.ReferenceEquals(resourceMan, null)) {
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("CSHTML5.Tools.CompatibilityAnalyzer.App.Properties.Resources", typeof(Resources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
             }
         }
-
+        
         /// <summary>
         ///   Overrides the current thread's CurrentUICulture property for all
         ///   resource lookups using this strongly typed resource class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Globalization.CultureInfo Culture
-        {
-            get
-            {
+        internal static global::System.Globalization.CultureInfo Culture {
+            get {
                 return resourceCulture;
             }
-            set
-            {
+            set {
                 resourceCulture = value;
             }
         }

--- a/CSHTML5.Tools.CompatibilityAnalyzer.App/Properties/Settings.Designer.cs
+++ b/CSHTML5.Tools.CompatibilityAnalyzer.App/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace CSHTML5.Tools.CompatibilityAnalyzer.App.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.4.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.8.1.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));

--- a/CSHTML5.Tools.CompatibilityAnalyzer.App/packages.config
+++ b/CSHTML5.Tools.CompatibilityAnalyzer.App/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Mono.Cecil" version="0.11.0" targetFramework="net45" />
-</packages>

--- a/CSHTML5.Tools.StubGenerator.App/CSHTML5.Tools.StubGenerator.App.csproj
+++ b/CSHTML5.Tools.StubGenerator.App/CSHTML5.Tools.StubGenerator.App.csproj
@@ -1,128 +1,26 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{9850A30B-17B9-4FD3-9799-0C2F7DCFBF24}</ProjectGuid>
+    <TargetFramework>net472</TargetFramework>
     <OutputType>WinExe</OutputType>
-    <RootNamespace>CSHTML5.Tools.StubGenerator.App</RootNamespace>
-    <AssemblyName>CSHTML5.Tools.StubGenerator.App</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <WarningLevel>4</WarningLevel>
-    <Deterministic>true</Deterministic>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <UseWindowsForms>true</UseWindowsForms>
+    <UseWPF>true</UseWPF>
+    <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
+    <Configurations>CSHTML5;OpenSilver</Configurations>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'CSHTML5|AnyCPU' ">
+	  <DefineConstants>TRACE;DEBUG;ASK_USER_TO_CHOOSE_ASSEMBLIES_TO_ANALYZE;CSHTML</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'OpenSilver|AnyCPU' ">
+	  <DefineConstants>TRACE;DEBUG;ASK_USER_TO_CHOOSE_ASSEMBLIES_TO_ANALYZE;OPENSILVER</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Mono.Cecil, Version=0.11.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
-      <HintPath>..\packages\Mono.Cecil.0.11.0\lib\net40\Mono.Cecil.dll</HintPath>
-    </Reference>
-    <Reference Include="Mono.Cecil.Mdb, Version=0.11.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
-      <HintPath>..\packages\Mono.Cecil.0.11.0\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
-    </Reference>
-    <Reference Include="Mono.Cecil.Pdb, Version=0.11.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
-      <HintPath>..\packages\Mono.Cecil.0.11.0\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
-    </Reference>
-    <Reference Include="Mono.Cecil.Rocks, Version=0.11.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
-      <HintPath>..\packages\Mono.Cecil.0.11.0\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Windows.Forms" />
-    <Reference Include="System.Xml" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xaml">
-      <RequiredTargetFramework>4.0</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="WindowsBase" />
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
+    <ProjectReference Include="..\CSHTML5.Tools.AssemblyAnalysisCommon\CSHTML5.Tools.AssemblyAnalysisCommon.csproj" />
+    <ProjectReference Include="..\CSHTML5.Tools.StubGenerator\CSHTML5.Tools.StubGenerator.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <ApplicationDefinition Include="App.xaml">
-      <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
-    </ApplicationDefinition>
-    <Page Include="MainWindow.xaml">
-      <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
-    </Page>
-    <Compile Include="App.xaml.cs">
-      <DependentUpon>App.xaml</DependentUpon>
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="MainWindow.xaml.cs">
-      <DependentUpon>MainWindow.xaml</DependentUpon>
-      <SubType>Code</SubType>
-    </Compile>
-    <Page Include="OptionsPicker.xaml">
-      <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
-    </Page>
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="Mono.Cecil" Version="0.11.0" />
+    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="OptionsPicker.xaml.cs">
-      <DependentUpon>OptionsPicker.xaml</DependentUpon>
-    </Compile>
-    <Compile Include="Properties\AssemblyInfo.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Properties\Resources.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-      <DependentUpon>Resources.resx</DependentUpon>
-    </Compile>
-    <Compile Include="Properties\Settings.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DependentUpon>Settings.settings</DependentUpon>
-      <DesignTimeSharedInput>True</DesignTimeSharedInput>
-    </Compile>
-    <EmbeddedResource Include="Properties\Resources.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
-    </EmbeddedResource>
-    <None Include="packages.config" />
-    <None Include="Properties\Settings.settings">
-      <Generator>SettingsSingleFileGenerator</Generator>
-      <LastGenOutput>Settings.Designer.cs</LastGenOutput>
-    </None>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="App.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\CSHTML5.Tools.AssemblyAnalysisCommon\CSHTML5.Tools.AssemblyAnalysisCommon.csproj">
-      <Project>{8bd10359-5315-4f6a-b82c-b0b0862ed4a2}</Project>
-      <Name>CSHTML5.Tools.AssemblyAnalysisCommon</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\CSHTML5.Tools.StubGenerator\CSHTML5.Tools.StubGenerator.csproj">
-      <Project>{b484d8cc-27f8-4a70-9968-9df1ec04600b}</Project>
-      <Name>CSHTML5.Tools.StubGenerator</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/CSHTML5.Tools.StubGenerator.App/MainWindow.xaml
+++ b/CSHTML5.Tools.StubGenerator.App/MainWindow.xaml
@@ -21,7 +21,8 @@
       <RowDefinition Height="Auto"/>
       <RowDefinition Height="Auto"/>
       <RowDefinition Height="Auto"/>
-    </Grid.RowDefinitions>
+       <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
     <Grid Grid.Row="0" Margin="0,10,0,0">
       <Grid.RowDefinitions>
         <RowDefinition/>
@@ -132,7 +133,21 @@
     <Grid Grid.Row="8" Margin="0,10,0,0" >
       <Button Content="Configure options" Click="ConfigureOptionsButtonClick" Padding="10,6" HorizontalAlignment="Left"/>
     </Grid>
-    <Grid Grid.Row="9" Margin="0,10,0,0" HorizontalAlignment="Center">
+        <Grid Grid.Row="9" Margin="0,10,0,0">
+
+            <Grid.RowDefinitions>
+                <RowDefinition/>
+                <RowDefinition/>
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="600"/>
+                <ColumnDefinition Width="50"/>
+            </Grid.ColumnDefinitions>
+            <TextBlock Grid.Row="0" Grid.ColumnSpan="2" Text="9. (Optional) Path to SL Migration Core assembly"/>
+            <TextBox x:Name="SLMigrationCoreAssemblyFolderPath" Grid.Row="1" Grid.Column="0" Text="Pick a file..."/>
+            <Button Grid.Row="1" Grid.Column="1" Content="Open..."  Click="SLMigrationCoreAssemblyButtonClick"/>
+        </Grid>
+    <Grid Grid.Row="10" Margin="0,10,0,0" HorizontalAlignment="Center">
       <Grid.ColumnDefinitions>
         <ColumnDefinition Width="Auto"/>
         <ColumnDefinition Width="Auto"/>

--- a/CSHTML5.Tools.StubGenerator.App/MainWindow.xaml.cs
+++ b/CSHTML5.Tools.StubGenerator.App/MainWindow.xaml.cs
@@ -1,4 +1,5 @@
-﻿using StubGenerator.Common.Options;
+﻿using DotNetForHtml5.PrivateTools.AssemblyAnalysisCommon;
+using StubGenerator.Common.Options;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -26,6 +27,7 @@ namespace DotNetForHtml5.PrivateTools
         public MainWindow()
         {
             InitializeComponent();
+            SLMigrationCoreAssemblyFolderPath.Text = StubGenerator.Common.Configuration.SLMigrationCoreAssemblyFolderPath;
         }
 
         private void ButtonGeneratedFilesFolderClick(object sender, RoutedEventArgs e)
@@ -238,6 +240,7 @@ namespace DotNetForHtml5.PrivateTools
             StubGenerator.Common.Configuration.ReferencedAssembliesFolderPath = ReferencedAssembliesFolderPath.Text;
             StubGenerator.Common.Configuration.PathOfDirectoryWhereFileAreGenerated = GeneratedFilesFolderPath.Text;
             StubGenerator.Common.Configuration.IsUsingVersion2 = CSHTML5Version.SelectedIndex == 0;
+            StubGenerator.Common.Configuration.SLMigrationCoreAssemblyFolderPath = SLMigrationCoreAssemblyFolderPath.Text;
             StubGenerator.Common.StubGenerator stubGenerator = new StubGenerator.Common.StubGenerator();
             stubGenerator.Run();
             PleaseWaitContainer.Visibility = Visibility.Collapsed;
@@ -263,6 +266,13 @@ namespace DotNetForHtml5.PrivateTools
             this.Close();
         }
 
-
+        private void SLMigrationCoreAssemblyButtonClick(object sender, RoutedEventArgs e)
+        {
+            OpenFileDialog openFileDialog = new OpenFileDialog();
+            if (openFileDialog.ShowDialog() == System.Windows.Forms.DialogResult.OK)
+            {
+                SLMigrationCoreAssemblyFolderPath.Text = openFileDialog.FileName;
+            }
+        }
     }
 }

--- a/CSHTML5.Tools.StubGenerator.App/packages.config
+++ b/CSHTML5.Tools.StubGenerator.App/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Mono.Cecil" version="0.11.0" targetFramework="net45" />
-</packages>

--- a/CSHTML5.Tools.StubGenerator/Analyzer/AssemblyAnalyzer.cs
+++ b/CSHTML5.Tools.StubGenerator/Analyzer/AssemblyAnalyzer.cs
@@ -21,9 +21,9 @@ namespace StubGenerator.Common.Analyzer
 
         public AssemblyDefinition Assembly { get; set; }
 
-        internal AssemblyAnalyzer(Dictionary<string, Dictionary<string, HashSet<string>>> unsupportedMethods, List<ModuleDefinition> modules, OutputOptions outputOptions)
+        internal AssemblyAnalyzer(string coreASsemblyFolder, Dictionary<string, Dictionary<string, HashSet<string>>> unsupportedMethods, List<ModuleDefinition> modules, OutputOptions outputOptions)
         {
-            Init(unsupportedMethods, modules, outputOptions);
+            Init(coreASsemblyFolder, unsupportedMethods, modules, outputOptions);
         }
 
         /// <summary>
@@ -32,7 +32,7 @@ namespace StubGenerator.Common.Analyzer
         /// <param name="unsupportedMethods"></param>
         /// <param name="modules"></param>
         /// <param name="outputOptions"></param>
-        private void Init(Dictionary<string, Dictionary<string, HashSet<string>>> unsupportedMethods, List<ModuleDefinition> modules, OutputOptions outputOptions = null)
+        private void Init(string coreASsemblyFolder, Dictionary<string, Dictionary<string, HashSet<string>>> unsupportedMethods, List<ModuleDefinition> modules, OutputOptions outputOptions = null)
         {
             if (!_isInitialized)
             {
@@ -47,7 +47,7 @@ namespace StubGenerator.Common.Analyzer
 
                 _unsupportedMethods = unsupportedMethods;
                 _modules = modules;
-                ClassAnalyzer = new ClassAnalyzer(_unsupportedMethods, _modules, _outputOptions);
+                ClassAnalyzer = new ClassAnalyzer(coreASsemblyFolder, _unsupportedMethods, _modules, _outputOptions);
 
                 _isInitialized = true;
             }

--- a/CSHTML5.Tools.StubGenerator/Analyzer/ClassAnalyzer.cs
+++ b/CSHTML5.Tools.StubGenerator/Analyzer/ClassAnalyzer.cs
@@ -48,9 +48,9 @@ namespace StubGenerator.Common.Analyzer
 
         private MethodAnalyzer MethodAnalyzer { get; set; }
 
-        internal ClassAnalyzer(Dictionary<string, Dictionary<string, HashSet<string>>> unsupportedMethods, List<ModuleDefinition> modules, OutputOptions outputOptions = null)
+        internal ClassAnalyzer(string coreASsemblyFolder, Dictionary<string, Dictionary<string, HashSet<string>>> unsupportedMethods, List<ModuleDefinition> modules, OutputOptions outputOptions = null)
         {
-            Init(unsupportedMethods, modules, outputOptions);
+            Init(coreASsemblyFolder, unsupportedMethods, modules, outputOptions);
         }
 
         /// <summary>
@@ -59,7 +59,7 @@ namespace StubGenerator.Common.Analyzer
         /// <param name="unsupportedMethods"></param>
         /// <param name="modules"></param>
         /// <param name="outputOptions"></param>
-        private void Init(Dictionary<string, Dictionary<string, HashSet<string>>> unsupportedMethods, List<ModuleDefinition> modules, OutputOptions outputOptions = null)
+        private void Init(string coreASsemblyFolder, Dictionary<string, Dictionary<string, HashSet<string>>> unsupportedMethods, List<ModuleDefinition> modules, OutputOptions outputOptions = null)
         {
             if (!_isInitialized)
             {
@@ -73,7 +73,7 @@ namespace StubGenerator.Common.Analyzer
                 }
                 if (!analyzeHelpher._initialized)
                 {
-                    CoreSupportedMethodsContainer coreSupportedMethods = new CoreSupportedMethodsContainer(System.IO.Path.Combine(AnalysisUtils.GetProgramFilesX86Path(), @"MSBuild\CSharpXamlForHtml5\InternalStuff\Compiler\SLMigration"));
+                    CoreSupportedMethodsContainer coreSupportedMethods = new CoreSupportedMethodsContainer(coreASsemblyFolder);
                     analyzeHelpher.Initialize(coreSupportedMethods, Configuration.supportedElementsPath);
                 }
 

--- a/CSHTML5.Tools.StubGenerator/CSHTML5.Tools.StubGenerator.csproj
+++ b/CSHTML5.Tools.StubGenerator/CSHTML5.Tools.StubGenerator.csproj
@@ -1,76 +1,16 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{B484D8CC-27F8-4A70-9968-9DF1EC04600B}</ProjectGuid>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>CSHTML5.Tools.StubGenerator</RootNamespace>
-    <AssemblyName>CSHTML5.Tools.StubGenerator</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <Deterministic>true</Deterministic>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+	  <Configurations>CSHTML5;OpenSilver</Configurations>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'CSHTML5|AnyCPU' ">
+	  <DefineConstants>TRACE;DEBUG;CSHTML</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'OpenSilver|AnyCPU' ">
+	  <DefineConstants>TRACE;DEBUG;OPENSILVER</DefineConstants>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Mono.Cecil, Version=0.11.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
-      <HintPath>..\packages\Mono.Cecil.0.11.0\lib\net40\Mono.Cecil.dll</HintPath>
-    </Reference>
-    <Reference Include="Mono.Cecil.Mdb, Version=0.11.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
-      <HintPath>..\packages\Mono.Cecil.0.11.0\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
-    </Reference>
-    <Reference Include="Mono.Cecil.Pdb, Version=0.11.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
-      <HintPath>..\packages\Mono.Cecil.0.11.0\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
-    </Reference>
-    <Reference Include="Mono.Cecil.Rocks, Version=0.11.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
-      <HintPath>..\packages\Mono.Cecil.0.11.0\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Analyzer\AssemblyAnalyzer.cs" />
-    <Compile Include="Analyzer\ClassAnalyzer.cs" />
-    <Compile Include="Analyzer\IElementAnalyzer.cs" />
-    <Compile Include="Analyzer\MethodAnalyzer.cs" />
-    <Compile Include="Builder\DefaultValueGenerator.cs" />
-    <Compile Include="Builder\FieldInfo.cs" />
-    <Compile Include="Builder\MethodInfo.cs" />
-    <Compile Include="Builder\PropertyInfo.cs" />
-    <Compile Include="Builder\TypeBuilder.cs" />
-    <Compile Include="Configuration.cs" />
-    <Compile Include="MethodInfo.cs" />
-    <Compile Include="MethodSignature.cs" />
-    <Compile Include="Options\OutputMethodOptions.cs" />
-    <Compile Include="Options\OutputOptions.cs" />
-    <Compile Include="Program.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="StubGenerator.cs" />
-  </ItemGroup>
   <ItemGroup>
     <Content Include="Resources\BridgeSupportedElements.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
@@ -80,13 +20,13 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\CSHTML5.Tools.AssemblyAnalysisCommon\CSHTML5.Tools.AssemblyAnalysisCommon.csproj">
-      <Project>{8bd10359-5315-4f6a-b82c-b0b0862ed4a2}</Project>
-      <Name>CSHTML5.Tools.AssemblyAnalysisCommon</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\CSHTML5.Tools.AssemblyAnalysisCommon\CSHTML5.Tools.AssemblyAnalysisCommon.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <ItemGroup>
+    <PackageReference Include="Mono.Cecil" Version="0.11.0" />
+  </ItemGroup>
 </Project>

--- a/CSHTML5.Tools.StubGenerator/Configuration.cs
+++ b/CSHTML5.Tools.StubGenerator/Configuration.cs
@@ -1,4 +1,5 @@
-﻿using StubGenerator.Common.Options;
+﻿using DotNetForHtml5.PrivateTools.AssemblyAnalysisCommon;
+using StubGenerator.Common.Options;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -53,6 +54,11 @@ namespace StubGenerator.Common
                 }
             }
         }
+
+        internal static string SLMigrationCoreAssemblyFolderPath = Path.Combine(
+            AnalysisUtils.GetProgramFilesX86Path(),
+            @"MSBuild\CSharpXamlForHtml5\InternalStuff\Compiler\SLMigration");
+
         // Path of supportedElements file
         internal static string supportedElementsPath = Path.Combine(Directory.GetCurrentDirectory(), "Resources\\BridgeSupportedElements.xml");
 

--- a/CSHTML5.Tools.StubGenerator/StubGenerator.cs
+++ b/CSHTML5.Tools.StubGenerator/StubGenerator.cs
@@ -38,7 +38,7 @@ namespace StubGenerator.Common
         {
             ILogger logger = new LoggerThatAggregatesAllErrors();
             List<UnsupportedMethodInfo> unsupportedMethodInfos = new List<UnsupportedMethodInfo>();
-            CoreSupportedMethodsContainer coreSupportedMethods = new CoreSupportedMethodsContainer(System.IO.Path.Combine(AnalysisUtils.GetProgramFilesX86Path(), @"MSBuild\CSharpXamlForHtml5\InternalStuff\Compiler\SLMigration"));
+            CoreSupportedMethodsContainer coreSupportedMethods = new CoreSupportedMethodsContainer(Configuration.SLMigrationCoreAssemblyFolderPath);
 
             foreach (string filename in _inputAssemblies)
             {
@@ -217,7 +217,11 @@ namespace StubGenerator.Common
             AnalysisUtils.SetModules(_modules);
             GetUnsupportedMethods();
             AddUndetectedMethodToUnsupportedMethods(Configuration.MethodsToAddManuallyBecauseTheyAreUndetected);
-            _assemblyAnalyzer = new AssemblyAnalyzer(_unsupportedMethodsInfo, _modules, _outputOptions);
+            _assemblyAnalyzer = new AssemblyAnalyzer(
+                Configuration.SLMigrationCoreAssemblyFolderPath, 
+                _unsupportedMethodsInfo,
+                _modules, 
+                _outputOptions);
         }
 
         /// <summary>

--- a/CSHTML5.Tools.StubGenerator/packages.config
+++ b/CSHTML5.Tools.StubGenerator/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Mono.Cecil" version="0.11.0" targetFramework="net45" />
-</packages>

--- a/CSHTML5.Tools.sln
+++ b/CSHTML5.Tools.sln
@@ -3,36 +3,36 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.29215.179
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CSHTML5.Tools.StubGenerator.App", "CSHTML5.Tools.StubGenerator.App\CSHTML5.Tools.StubGenerator.App.csproj", "{9850A30B-17B9-4FD3-9799-0C2F7DCFBF24}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CSHTML5.Tools.StubGenerator.App", "CSHTML5.Tools.StubGenerator.App\CSHTML5.Tools.StubGenerator.App.csproj", "{9850A30B-17B9-4FD3-9799-0C2F7DCFBF24}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CSHTML5.Tools.StubGenerator", "CSHTML5.Tools.StubGenerator\CSHTML5.Tools.StubGenerator.csproj", "{B484D8CC-27F8-4A70-9968-9DF1EC04600B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CSHTML5.Tools.StubGenerator", "CSHTML5.Tools.StubGenerator\CSHTML5.Tools.StubGenerator.csproj", "{B484D8CC-27F8-4A70-9968-9DF1EC04600B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CSHTML5.Tools.AssemblyAnalysisCommon", "CSHTML5.Tools.AssemblyAnalysisCommon\CSHTML5.Tools.AssemblyAnalysisCommon.csproj", "{8BD10359-5315-4F6A-B82C-B0B0862ED4A2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CSHTML5.Tools.AssemblyAnalysisCommon", "CSHTML5.Tools.AssemblyAnalysisCommon\CSHTML5.Tools.AssemblyAnalysisCommon.csproj", "{8BD10359-5315-4F6A-B82C-B0B0862ED4A2}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CSHTML5.Tools.CompatibilityAnalyzer.App", "CSHTML5.Tools.CompatibilityAnalyzer.App\CSHTML5.Tools.CompatibilityAnalyzer.App.csproj", "{99771B41-0FCF-46A7-AC96-ED557EC05DD6}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CSHTML5.Tools.CompatibilityAnalyzer.App", "CSHTML5.Tools.CompatibilityAnalyzer.App\CSHTML5.Tools.CompatibilityAnalyzer.App.csproj", "{99771B41-0FCF-46A7-AC96-ED557EC05DD6}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-		Release|Any CPU = Release|Any CPU
+		CSHTML5|Any CPU = CSHTML5|Any CPU
+		OpenSilver|Any CPU = OpenSilver|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{9850A30B-17B9-4FD3-9799-0C2F7DCFBF24}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{9850A30B-17B9-4FD3-9799-0C2F7DCFBF24}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{9850A30B-17B9-4FD3-9799-0C2F7DCFBF24}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{9850A30B-17B9-4FD3-9799-0C2F7DCFBF24}.Release|Any CPU.Build.0 = Release|Any CPU
-		{B484D8CC-27F8-4A70-9968-9DF1EC04600B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{B484D8CC-27F8-4A70-9968-9DF1EC04600B}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{B484D8CC-27F8-4A70-9968-9DF1EC04600B}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{B484D8CC-27F8-4A70-9968-9DF1EC04600B}.Release|Any CPU.Build.0 = Release|Any CPU
-		{8BD10359-5315-4F6A-B82C-B0B0862ED4A2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{8BD10359-5315-4F6A-B82C-B0B0862ED4A2}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{8BD10359-5315-4F6A-B82C-B0B0862ED4A2}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{8BD10359-5315-4F6A-B82C-B0B0862ED4A2}.Release|Any CPU.Build.0 = Release|Any CPU
-		{99771B41-0FCF-46A7-AC96-ED557EC05DD6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{99771B41-0FCF-46A7-AC96-ED557EC05DD6}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{99771B41-0FCF-46A7-AC96-ED557EC05DD6}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{99771B41-0FCF-46A7-AC96-ED557EC05DD6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9850A30B-17B9-4FD3-9799-0C2F7DCFBF24}.CSHTML5|Any CPU.ActiveCfg = CSHTML5|Any CPU
+		{9850A30B-17B9-4FD3-9799-0C2F7DCFBF24}.CSHTML5|Any CPU.Build.0 = CSHTML5|Any CPU
+		{9850A30B-17B9-4FD3-9799-0C2F7DCFBF24}.OpenSilver|Any CPU.ActiveCfg = OpenSilver|Any CPU
+		{9850A30B-17B9-4FD3-9799-0C2F7DCFBF24}.OpenSilver|Any CPU.Build.0 = OpenSilver|Any CPU
+		{B484D8CC-27F8-4A70-9968-9DF1EC04600B}.CSHTML5|Any CPU.ActiveCfg = CSHTML5|Any CPU
+		{B484D8CC-27F8-4A70-9968-9DF1EC04600B}.CSHTML5|Any CPU.Build.0 = CSHTML5|Any CPU
+		{B484D8CC-27F8-4A70-9968-9DF1EC04600B}.OpenSilver|Any CPU.ActiveCfg = OpenSilver|Any CPU
+		{B484D8CC-27F8-4A70-9968-9DF1EC04600B}.OpenSilver|Any CPU.Build.0 = OpenSilver|Any CPU
+		{8BD10359-5315-4F6A-B82C-B0B0862ED4A2}.CSHTML5|Any CPU.ActiveCfg = CSHTML5|Any CPU
+		{8BD10359-5315-4F6A-B82C-B0B0862ED4A2}.CSHTML5|Any CPU.Build.0 = CSHTML5|Any CPU
+		{8BD10359-5315-4F6A-B82C-B0B0862ED4A2}.OpenSilver|Any CPU.ActiveCfg = OpenSilver|Any CPU
+		{8BD10359-5315-4F6A-B82C-B0B0862ED4A2}.OpenSilver|Any CPU.Build.0 = OpenSilver|Any CPU
+		{99771B41-0FCF-46A7-AC96-ED557EC05DD6}.CSHTML5|Any CPU.ActiveCfg = CSHTML5|Any CPU
+		{99771B41-0FCF-46A7-AC96-ED557EC05DD6}.CSHTML5|Any CPU.Build.0 = CSHTML5|Any CPU
+		{99771B41-0FCF-46A7-AC96-ED557EC05DD6}.OpenSilver|Any CPU.ActiveCfg = OpenSilver|Any CPU
+		{99771B41-0FCF-46A7-AC96-ED557EC05DD6}.OpenSilver|Any CPU.Build.0 = OpenSilver|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/OpenSilver.Tools.sln
+++ b/OpenSilver.Tools.sln
@@ -1,0 +1,43 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29215.179
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CSHTML5.Tools.StubGenerator.App", "CSHTML5.Tools.StubGenerator.App\CSHTML5.Tools.StubGenerator.App.csproj", "{9850A30B-17B9-4FD3-9799-0C2F7DCFBF24}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CSHTML5.Tools.StubGenerator", "CSHTML5.Tools.StubGenerator\CSHTML5.Tools.StubGenerator.csproj", "{B484D8CC-27F8-4A70-9968-9DF1EC04600B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CSHTML5.Tools.AssemblyAnalysisCommon", "CSHTML5.Tools.AssemblyAnalysisCommon\CSHTML5.Tools.AssemblyAnalysisCommon.csproj", "{8BD10359-5315-4F6A-B82C-B0B0862ED4A2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CSHTML5.Tools.CompatibilityAnalyzer.App", "CSHTML5.Tools.CompatibilityAnalyzer.App\CSHTML5.Tools.CompatibilityAnalyzer.App.csproj", "{99771B41-0FCF-46A7-AC96-ED557EC05DD6}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		CSHTML5|Any CPU = CSHTML5|Any CPU
+		OpenSilver|Any CPU = OpenSilver|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{9850A30B-17B9-4FD3-9799-0C2F7DCFBF24}.CSHTML5|Any CPU.ActiveCfg = CSHTML5|Any CPU
+		{9850A30B-17B9-4FD3-9799-0C2F7DCFBF24}.CSHTML5|Any CPU.Build.0 = CSHTML5|Any CPU
+		{9850A30B-17B9-4FD3-9799-0C2F7DCFBF24}.OpenSilver|Any CPU.ActiveCfg = OpenSilver|Any CPU
+		{9850A30B-17B9-4FD3-9799-0C2F7DCFBF24}.OpenSilver|Any CPU.Build.0 = OpenSilver|Any CPU
+		{B484D8CC-27F8-4A70-9968-9DF1EC04600B}.CSHTML5|Any CPU.ActiveCfg = CSHTML5|Any CPU
+		{B484D8CC-27F8-4A70-9968-9DF1EC04600B}.CSHTML5|Any CPU.Build.0 = CSHTML5|Any CPU
+		{B484D8CC-27F8-4A70-9968-9DF1EC04600B}.OpenSilver|Any CPU.ActiveCfg = OpenSilver|Any CPU
+		{B484D8CC-27F8-4A70-9968-9DF1EC04600B}.OpenSilver|Any CPU.Build.0 = OpenSilver|Any CPU
+		{8BD10359-5315-4F6A-B82C-B0B0862ED4A2}.CSHTML5|Any CPU.ActiveCfg = CSHTML5|Any CPU
+		{8BD10359-5315-4F6A-B82C-B0B0862ED4A2}.CSHTML5|Any CPU.Build.0 = CSHTML5|Any CPU
+		{8BD10359-5315-4F6A-B82C-B0B0862ED4A2}.OpenSilver|Any CPU.ActiveCfg = OpenSilver|Any CPU
+		{8BD10359-5315-4F6A-B82C-B0B0862ED4A2}.OpenSilver|Any CPU.Build.0 = OpenSilver|Any CPU
+		{99771B41-0FCF-46A7-AC96-ED557EC05DD6}.CSHTML5|Any CPU.ActiveCfg = OpenSilver|Any CPU
+		{99771B41-0FCF-46A7-AC96-ED557EC05DD6}.CSHTML5|Any CPU.Build.0 = OpenSilver|Any CPU
+		{99771B41-0FCF-46A7-AC96-ED557EC05DD6}.OpenSilver|Any CPU.ActiveCfg = OpenSilver|Any CPU
+		{99771B41-0FCF-46A7-AC96-ED557EC05DD6}.OpenSilver|Any CPU.Build.0 = OpenSilver|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {568E60D1-145E-48F5-AC41-2FBC6970BCC1}
+	EndGlobalSection
+EndGlobal

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ To create stubs from your Silverlight 3rd-party referenced libraries, please fol
 
 ![Folder screenshot](/screenshots/config_folder3.png "Folder screenshot")
 
+(Optional) If you want to use a specific OpenSilver.dll instead of CSHTML5, compile the OpenSilver configuration and set Field #9 to the compilation output dir e.g. OpenSilver\src\Runtime\Runtime\bin\OpenSilver\SL.WorkInProgress\netstandard2.0
+
 You can leave the other fields empty or with their default value for now.
 
 5. Click "Start" to generate the stubs. A message will appear indicating that the operation may take a few minutes.


### PR DESCRIPTION
Code changes to achieve two goals:
- Identify code that's missing in the OpenSilver.dll for the Talentia Silverlight based projects
- Generate simpler stubs for used 3rd party components

Commit log:
+ Migrated projects to use Project.SDK
+ Updated configurations to CSHTML5 and OpenSilver with OpenSilver dll being used in the later
+ Added possibility to reference custom OpenSilver dll (e.g. SL.WIP variant) when using OpenSilver
+ Added a try catch in MethodAnalyzer.CanWorkOnElement with logging due to some exceptions (on some generics?)

Tested on OpenSilver.WIP vs OpenSilver and the expected differences were should in the code analyzer
Couldn't test on CSHTML5